### PR TITLE
Use Activity Result API

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,17 @@
 
 
 There are code comments throughout the project explaining various issues that prevent the SDK to return control back to the App after Android System kills the App while its in background.
+
+## Alternative Re-creation Steps using Android Debug Bridge (ADB)
+
+> NOTE: These steps only apply if Android SDK Platform Tools are installed
+
+1. Update SDK Location in local.properties
+2. To Recreate the crash:
+   1. Run the 'App' project
+   2. You will see a Activity with 'Start SDK activity' Button. Once you click the button, you will be taken the SDK activity (similar to challenge screen).
+   3. Put the App in background, with home key.
+   4. Open Terminal (or other CLI program) and run `adb shell am kill com.example.myapplication`
+   5. Re-open the app from the Multitasking pane.
+   6. Press 'Return to App' button || CRASH happens here.
+

--- a/app/src/main/java/com/example/myapplication/MainActivity.java
+++ b/app/src/main/java/com/example/myapplication/MainActivity.java
@@ -5,6 +5,7 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.util.Log;
 import android.widget.Button;
+import android.widget.TextView;
 
 import androidx.activity.result.ActivityResult;
 import androidx.activity.result.ActivityResultCallback;
@@ -23,15 +24,29 @@ public class MainActivity extends AppCompatActivity {
             new ActivityResultCallback<ActivityResult>() {
                 @Override
                 public void onActivityResult(ActivityResult result) {
-                    if (result.getResultCode() == Activity.RESULT_OK) {
-                        Intent intent = result.getData();
-                        if (intent != null) {
-                            String message = intent.getStringExtra(LibraryActivity.EXTRA_MESSAGE);
-                            if (message != null) {
-                                Log.d(TAG, String.format("Message: %s", message));
+                    TextView resultTextView = findViewById(R.id.resultTextView);
+                    int resultCode = result.getResultCode();
+
+                    String message = null;
+                    switch (resultCode) {
+                        case Activity.RESULT_OK:
+                            Intent intent = result.getData();
+                            if (intent != null) {
+                                message = intent.getStringExtra(LibraryActivity.EXTRA_MESSAGE);
                             }
-                        }
+                            break;
+                        case Activity.RESULT_CANCELED:
+                            message = "CANCELED";
+                            break;
+                        default:
+                            message = "UNKNOWN";
                     }
+
+                    String resultText = String.format("Result: %s", message) ;
+                    Log.d(TAG, resultText);
+
+                    // also display result on screen
+                    resultTextView.setText(resultText);
                 }
             });
 
@@ -69,6 +84,10 @@ public class MainActivity extends AppCompatActivity {
     }
 
     void startLibraryActivity() {
+        // clear result text
+        TextView resultTextView = findViewById(R.id.resultTextView);
+        resultTextView.setText("");
+
         Intent intent = new Intent(this, LibraryActivity.class);
         // Ref: https://stackoverflow.com/a/48177487
         intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);

--- a/app/src/main/java/com/example/myapplication/MainActivity.java
+++ b/app/src/main/java/com/example/myapplication/MainActivity.java
@@ -1,16 +1,39 @@
 package com.example.myapplication;
 
-import android.content.Context;
+import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
+import android.util.Log;
 import android.widget.Button;
 
+import androidx.activity.result.ActivityResult;
+import androidx.activity.result.ActivityResultCallback;
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.appcompat.app.AppCompatActivity;
 
-import com.example.testlibrary.CallbackService;
-import com.example.testlibrary.LibraryService;
+import com.example.testlibrary.LibraryActivity;
 
 public class MainActivity extends AppCompatActivity {
+
+    private static final String TAG = "MainActivity";
+
+    ActivityResultLauncher<Intent> activityLauncher = registerForActivityResult(
+            new ActivityResultContracts.StartActivityForResult(),
+            new ActivityResultCallback<ActivityResult>() {
+                @Override
+                public void onActivityResult(ActivityResult result) {
+                    if (result.getResultCode() == Activity.RESULT_OK) {
+                        Intent intent = result.getData();
+                        if (intent != null) {
+                            String message = intent.getStringExtra(LibraryActivity.EXTRA_MESSAGE);
+                            if (message != null) {
+                                Log.d(TAG, String.format("Message: %s", message));
+                            }
+                        }
+                    }
+                }
+            });
 
     /**
      * Before getting started: update SDK location in local.properties.
@@ -46,14 +69,9 @@ public class MainActivity extends AppCompatActivity {
     }
 
     void startLibraryActivity() {
-        LibraryService libraryService = new LibraryService();
-        libraryService.startMockChallenge(this, new CallbackService() {
-            @Override
-            public void onValidated(Context currentContext, String result) {
-                Intent intent = new Intent(currentContext, ResultActivity.class);
-                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                currentContext.startActivity(intent);
-            }
-        });
+        Intent intent = new Intent(this, LibraryActivity.class);
+        // Ref: https://stackoverflow.com/a/48177487
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        activityLauncher.launch(intent);
     }
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -27,4 +27,15 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/textView3" />
 
+    <TextView
+        android:id="@+id/resultTextView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="15dp"
+        android:textSize="20sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/appButton"
+        tools:text="Example Text" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/testlibrary/src/main/java/com/example/testlibrary/LibraryActivity.java
+++ b/testlibrary/src/main/java/com/example/testlibrary/LibraryActivity.java
@@ -65,8 +65,4 @@ public class LibraryActivity extends AppCompatActivity {
         super.onDestroy();
         System.out.println("LibraryActivity: " + "onDestroy() called");
     }
-
-    @Override
-    public void onBackPressed() {
-    }
 }

--- a/testlibrary/src/main/java/com/example/testlibrary/LibraryActivity.java
+++ b/testlibrary/src/main/java/com/example/testlibrary/LibraryActivity.java
@@ -1,5 +1,7 @@
 package com.example.testlibrary;
 
+import android.app.Activity;
+import android.content.Intent;
 import android.os.Bundle;
 import android.widget.Button;
 
@@ -7,12 +9,20 @@ import androidx.appcompat.app.AppCompatActivity;
 
 public class LibraryActivity extends AppCompatActivity {
 
+    public static String EXTRA_MESSAGE = "com.example.testlibrary.EXTRA_MESSAGE";
+
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_library);
         Button returnToApp = findViewById(R.id.return_to_app_button);
-        returnToApp.setOnClickListener(view -> UIInteractionFactory.getInstance().sendUserResponse(view.getContext(), "SUCCESS"));
+        returnToApp.setOnClickListener(view -> {
+            Intent data = new Intent();
+            data.putExtra(LibraryActivity.EXTRA_MESSAGE, "SUCCESS");
+            setResult(Activity.RESULT_OK, data);
+            finish();
+        });
     }
 
     @Override


### PR DESCRIPTION
### Summary of changes

 - This PR replaces the `CallbackService` pattern with the [Activity Result API](https://developer.android.com/training/basics/intents/result)
- The Activity Result API gives `LibraryActivity` the ability to return a result to `MainActivity` after a process kill

 ### Checklist

 ~- [ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire